### PR TITLE
Remove support for windows2016 stack

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,7 +14,3 @@ binary-buildpack/binary_buildpack-windows2012R2-v1.0.33.zip:
   size: 9519934
   object_id: 6786bafb-ba90-42b2-58bb-6f11ab4d173b
   sha: sha256:6f312bf165849fd1f899b2ecfae93b35a72b9bf1753b1f07d629fa366ca8a103
-binary-buildpack/binary_buildpack-windows2016-v1.0.33.zip:
-  size: 9519929
-  object_id: 688afee9-5f4f-42e1-65a1-f9f99325978b
-  sha: sha256:ceaf5ffcccf0283c6d07f94279fc9be248377510eb3b61e85290293a2150bcb8

--- a/jobs/binary-buildpack/spec
+++ b/jobs/binary-buildpack/spec
@@ -6,7 +6,6 @@ packages:
 - binary-buildpack-cflinuxfs2
 - binary-buildpack-cflinuxfs3
 - binary-buildpack-windows2012R2
-- binary-buildpack-windows2016
 - binary-buildpack-windows
 
 properties: {}

--- a/packages/binary-buildpack-windows2016/packaging
+++ b/packages/binary-buildpack-windows2016/packaging
@@ -1,2 +1,0 @@
-    set -e -x
-    cp binary-buildpack/binary?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/binary-buildpack-windows2016/spec
+++ b/packages/binary-buildpack-windows2016/spec
@@ -1,4 +1,0 @@
----
-name: binary-buildpack-windows2016
-files:
-- binary-buildpack/binary?buildpack-windows2016-v*.zip


### PR DESCRIPTION
This change removes `binary_buildpack-windows2016` from the release.

The `windows2016` stack is no longer supported. See [cloudfoundry docs](https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html):

> "If you push your Cloud Foundry app to a Windows stack, you must use windows. The `windows2016` stack is not supported on Cloud Foundry."

`windows2016` and `windows` stacks are equivalent, but `windows2016` was deprecated and is now being removed to avoid confusion.